### PR TITLE
hay que quitar el color del css para no tener conflicto

### DIFF
--- a/src/app/shared/components/block-item/block-item.component.css
+++ b/src/app/shared/components/block-item/block-item.component.css
@@ -1,5 +1,5 @@
 .day {
-  @apply bg-slate-200 border-2 border-slate-300 transition-all cursor-pointer w-10 h-10 rounded-lg;
+  @apply border-2 transition-all cursor-pointer w-10 h-10 rounded-lg;
 }
 
 .tooltip {


### PR DESCRIPTION
hay que quitar el color del css para no tener conflicto con el otro que añades por ngclass